### PR TITLE
Add a related work

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Awesome-Long2short-on-LRMs is a collection of state-of-the-art, novel, exciting 
 | 2025.03 | **L1: Controlling How Long A Reasoning Model Thinks With Reinforcement Learning** | arXiv | [link](https://www.arxiv.org/pdf/2503.04697) | [link](https://github.com/cmu-l3/l1) |
 | 2025.03 | **InftyThink: Breaking the Length Limits of Long-Context Reasoning in Large Language Models** |   arXiv     | [link](https://arxiv.org/abs/2503.06692) |        -     |
 | 2025.03 | **EAGLE-3: Scaling up Inference Acceleration of Large Language Models via Training-Time Test** | arXiv | [link](https://arxiv.org/pdf/2503.01840v1) | [link](https://github.com/SafeAILab/EAGLE) |
+| 2025.02 | **LongSpec: Long-Context Speculative Decoding with Efficient Drafting and Verification** | arXiv | [link](https://arxiv.org/pdf/2502.17421) | [link](https://github.com/sail-sg/LongSpec) |
 | 2025.02 | **Do NOT Think That Much for 2+3=? On the Overthinking of o1-Like LLMs** |   arXiv     | [link](https://arxiv.org/abs/2412.21187) |        -    |
 | 2025.02 | **Self-Training Elicits Concise Reasoning in Large Language Models** |   arXiv     | [link](https://arxiv.org/abs/2502.20122) |        [link](https://github.com/TergelMunkhbat/concise-reasoning)    |
 | 2025.02 | **TokenSkip: Controllable Chain-of-Thought Compression in LLMs** |   arXiv     | [link](https://arxiv.org/abs/2502.12067) |        [link](https://github.com/hemingkx/TokenSkip)     |


### PR DESCRIPTION
Hi, I’d like to propose adding our recent work LongSpec: Long-Context Speculative Decoding with Efficient Drafting and Verification to the paper list. 

LongSpec introduces a speculative decoding method that can accelerate long-context chain-of-thought reasoning with efficient drafting and verification. We also release a draft model for QwQ-32B-preview. Since related works like EAGLE-3 are already included, I believe this paper is a good fit.

Paper: https://arxiv.org/abs/2502.17421
Project page: https://sail-sg.github.io/LongSpec/

Thanks for considering!